### PR TITLE
Enable TCP_NODELAY for all TCP connections

### DIFF
--- a/src/com/intelligt/modbus/jlibmodbus/net/ModbusMasterConnectionTCP.java
+++ b/src/com/intelligt/modbus/jlibmodbus/net/ModbusMasterConnectionTCP.java
@@ -66,6 +66,7 @@ class ModbusMasterConnectionTCP extends ModbusConnection {
                 try {
                     socket.connect(isa, parameters.getConnectionTimeout());
                     socket.setKeepAlive(parameters.isKeepAlive());
+                    socket.setTcpNoDelay(true);
 
                     transport = ModbusTransportFactory.createTCP(socket);
                     setReadTimeout(getReadTimeout());

--- a/src/com/intelligt/modbus/jlibmodbus/serial/SerialPortFactoryTcpClient.java
+++ b/src/com/intelligt/modbus/jlibmodbus/serial/SerialPortFactoryTcpClient.java
@@ -82,6 +82,7 @@ public class SerialPortFactoryTcpClient extends SerialPortAbstractFactory {
                     socket.connect(isa, Modbus.MAX_CONNECTION_TIMEOUT);
                     socket.setKeepAlive(parameters.isKeepAlive());
                     socket.setSoTimeout(getReadTimeout());
+                    socket.setTcpNoDelay(true);
 
                     is = new InputStreamTCP(socket);
                     os = new OutputStreamTCP(socket);

--- a/src/com/intelligt/modbus/jlibmodbus/serial/SerialPortFactoryTcpServer.java
+++ b/src/com/intelligt/modbus/jlibmodbus/serial/SerialPortFactoryTcpServer.java
@@ -188,6 +188,7 @@ public class SerialPortFactoryTcpServer extends SerialPortAbstractFactory {
             try {
                 while (isListening()) {
                     client = server.accept();
+                    client.setTcpNoDelay(true);
                     is = new InputStreamTCP(client);
                     os = new OutputStreamTCP(client);
                     while (client.isConnected() && isListening()) {

--- a/src/com/intelligt/modbus/jlibmodbus/slave/ModbusSlaveTCP.java
+++ b/src/com/intelligt/modbus/jlibmodbus/slave/ModbusSlaveTCP.java
@@ -118,6 +118,7 @@ public class ModbusSlaveTCP extends ModbusSlave implements Runnable {
         try {
             while (isListening()) {
                 s = server.accept();
+                s.setTcpNoDelay(true);
                 try {
                     threadPool.execute(new RequestHandlerTCP(this, s));
                 } catch (ModbusIOException ioe) {


### PR DESCRIPTION
TCP_NODELAY avoids a delay of sending TCP packets with a small payload.

fix #57