### PR TITLE
ModbusSlaveTCP/Fix binding to specific InetAddress

### DIFF
--- a/src/com/intelligt/modbus/jlibmodbus/slave/ModbusSlaveTCP.java
+++ b/src/com/intelligt/modbus/jlibmodbus/slave/ModbusSlaveTCP.java
@@ -55,7 +55,7 @@ public class ModbusSlaveTCP extends ModbusSlave implements Runnable {
     @Override
     synchronized public void listenImpl() throws ModbusIOException {
         try {
-            server = new ServerSocket(tcp.getPort());
+            server = new ServerSocket(tcp.getPort(), 0, tcp.getHost());
             mainThread = new Thread(this);
             setListening(true);
             mainThread.start();


### PR DESCRIPTION
InetAddress in TcpParameters was not taken into account when creating Modbus Slave (server). This patch allows to take the address in account. 2 parameter to ServerSocket, backlog, is set to 0 as the doc says it will default to implementation specific default.