### PR TITLE
Use System.nanoTime() instead of System.currentTimeMillis()

### DIFF
--- a/src/com/intelligt/modbus/jlibmodbus/master/ModbusMaster.java
+++ b/src/com/intelligt/modbus/jlibmodbus/master/ModbusMaster.java
@@ -1,5 +1,7 @@
 package com.intelligt.modbus.jlibmodbus.master;
 
+import java.util.concurrent.TimeUnit;
+
 import com.intelligt.modbus.jlibmodbus.Modbus;
 import com.intelligt.modbus.jlibmodbus.data.CommStatus;
 import com.intelligt.modbus.jlibmodbus.exception.ModbusIOException;
@@ -47,7 +49,7 @@ abstract public class ModbusMaster implements FrameEventListenerList {
     final private ModbusConnection conn;
     final private BroadcastResponse broadcastResponse = new BroadcastResponse();
     private int transactionId = 0;
-    private long requestTime = 0;
+    private long requestTimeNs = 0;
 
     public ModbusMaster(ModbusConnection conn) {
         this.conn = conn;
@@ -104,7 +106,7 @@ abstract public class ModbusMaster implements FrameEventListenerList {
         if (transport == null)
             throw new ModbusIOException("transport is null");
         transport.send(msg);
-        requestTime = System.currentTimeMillis();
+        requestTimeNs = System.nanoTime();
     }
 
     protected ModbusMessage readResponse(ModbusRequest request) throws ModbusProtocolException, ModbusNumberException, ModbusIOException {
@@ -146,7 +148,7 @@ abstract public class ModbusMaster implements FrameEventListenerList {
                     } catch (ModbusNumberException mne) {
                         Modbus.log().warning(mne.getLocalizedMessage());
                     }
-                } while (System.currentTimeMillis() - requestTime < getConnection().getReadTimeout());
+                } while (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - requestTimeNs) < getConnection().getReadTimeout());
                 /*
                  * throw an exception if there is a response timeout
                  */

--- a/src/com/intelligt/modbus/jlibmodbus/serial/SerialPortAT.java
+++ b/src/com/intelligt/modbus/jlibmodbus/serial/SerialPortAT.java
@@ -6,6 +6,7 @@ import com.intelligt.modbus.jlibmodbus.Modbus;
 import com.intelligt.modbus.jlibmodbus.utils.ByteFifo;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 /*
  * Copyright (C) 2017 Vladislav Y. Kochedykov
@@ -34,7 +35,7 @@ public class SerialPortAT extends SerialPort {
 
     private UartDevice port;
     byte[] buffer = new byte[Modbus.MAX_PDU_LENGTH];
-    volatile long readTime = 0;
+    volatile long readTimeNs = 0;
 
     public SerialPortAT(SerialParameters sp) {
         super(sp);
@@ -77,9 +78,9 @@ public class SerialPortAT extends SerialPort {
     @Override
     public int read() throws IOException {
         try {
-            readTime = System.currentTimeMillis();
+            readTimeNs = System.nanoTime();
             while (port.read(buffer, 1) < 1) {
-                if ((System.currentTimeMillis() - readTime) > getReadTimeout()) {
+                if (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - readTimeNs) > getReadTimeout()) {
                     throw new IOException("Read timeout");
                 }
             }
@@ -92,7 +93,7 @@ public class SerialPortAT extends SerialPort {
     @Override
     public int read(byte[] b, int off, final int len) throws IOException {
         try {
-            readTime = System.currentTimeMillis();
+            readTimeNs = System.nanoTime();
             int read;
             int count = 0;
 
@@ -112,7 +113,7 @@ public class SerialPortAT extends SerialPort {
                 System.arraycopy(buffer, 0, b, off, read);
                 off += read;
 
-                if ((System.currentTimeMillis() - readTime) > getReadTimeout()) {
+                if (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - readTimeNs) > getReadTimeout()) {
                     throw new IOException("Read timeout");
                 }
             }


### PR DESCRIPTION
The value of System.currentTimeMillis() might jump if the system
wall-clock is changed e.g. by NTP. Therefore it should not be used for
measuring elapsed time.

System.nanoTime() is not affected by time steps of the system wall-clock
and can better be used for measuring elapsed time.