### PR TITLE
fix(util): The problem of transforming byte[] into int[]

### DIFF
--- a/src/com/intelligt/modbus/jlibmodbus/utils/DataUtils.java
+++ b/src/com/intelligt/modbus/jlibmodbus/utils/DataUtils.java
@@ -74,9 +74,15 @@ public class DataUtils {
     }
 
     static public int[] BeToIntArray(byte[] bytes) {
-        int[] dst = new int[bytes.length / 2];
-        for (int i = 0, j = 0; i < dst.length; i++, j += 2)
-            dst[i] = ((bytes[j] & 0xff) << 8) | (bytes[j + 1] & 0xff);
+        int[] dst = new int[bytes.length / 4];
+        int i = 0;
+        for (int j = 0; i < dst.length; j += 4) {
+            dst[i] = ((bytes[j] )<< 24) |
+                    ((bytes[j + 1] & 0xFF) << 16)
+                    | ((bytes[j + 2] & 0xFF) << 8)
+                    | ((bytes[j + 3]) & 0xFF);
+            ++i;
+        }
         return dst;
     }
 


### PR DESCRIPTION
Int in Java is the 32 bit basic data type, and byte is the data type of
8 bits. So when the byte array is turned to int, should it be 4 byte
bytes converted to one data