### PR TITLE
CheckRegister value does truncate negative values

### DIFF
--- a/src/com/intelligt/modbus/jlibmodbus/Modbus.java
+++ b/src/com/intelligt/modbus/jlibmodbus/Modbus.java
@@ -290,7 +290,7 @@ final public class Modbus {
      * @return "true" if register value is correct, else "false".
      */
     static public boolean checkRegisterValue(int value) {
-        return checkRange((short)value, 0, Modbus.MAX_REGISTER_VALUE);
+        return checkRange((short)value, Short.MIN_VALUE, Short.MAX_VALUE);
     }
 
     /**


### PR DESCRIPTION
Method checkRegisterValue can be called with a negative integer value that would still be valid to be stored in a Short. However checkRange checks the value is btw 0 to MAX_REGISTER value in my opinion it should be btw Short.MIN_VALUE and Short.MAX_VALUE