### PR TITLE
Supports Slaves that supports 48-bits like the ELESTER devices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
             <url>https://mvnrepository.com/</url>
         </repository>
     </repositories>
-    <!--init commit-->
     <dependencies>
         <!-- http://fazecast.github.io/jSerialComm -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
             <url>https://mvnrepository.com/</url>
         </repository>
     </repositories>
+    <!--init commit-->
     <dependencies>
         <!-- http://fazecast.github.io/jSerialComm -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+            <!--<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>1.5</version>
@@ -140,7 +140,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin>-->
         </plugins>
     </build>
     <licenses>

--- a/src/com/intelligt/modbus/jlibmodbus/data/ModbusHoldingRegisters.java
+++ b/src/com/intelligt/modbus/jlibmodbus/data/ModbusHoldingRegisters.java
@@ -118,11 +118,21 @@ public class ModbusHoldingRegisters extends ModbusValues<Integer> {
     }
 
     public int getInt32At(int offset) throws IllegalDataAddressException {
-        return (getInt16At(offset)&0xffff) | ((getInt16At(offset + 1)&0xffff) << 16);
+        return (getInt16At(offset) & 0xffff) | ((getInt16At(offset + 1) & 0xffff) << 16);
     }
 
     public long getInt64At(int offset) throws IllegalDataAddressException {
-        return (getInt32At(offset)&0xffffffffL) | ((getInt32At(offset + 2)&0xffffffffL) << 32);
+        return (getInt32At(offset) & 0xffffffffL) | ((getInt32At(offset + 2) & 0xffffffffL) << 32);
+    }
+
+    public float getFloat48BigEndian() {
+        return (float) ((registers[0] * Math.pow(2, 32)) + (registers[1] * Math.pow(2, 16))
+                + (registers[2] * Math.pow(2, 0)));
+    }
+
+    public float getFloat48LittleEndian() {
+        return (float) ((registers[0] * Math.pow(2, 0)) + (registers[1] * Math.pow(2, 16))
+                + (registers[2] * Math.pow(2, 32)));
     }
 
     public float getFloat32At(int offset) throws IllegalDataAddressException {


### PR DESCRIPTION
- Edit the Jlibmodbus library to support the little endian and big endian Modbus slaves which contain three registers in holding registers (48 bits).