### PR TITLE
Set timeout for SlaveTcp

### DIFF
--- a/examples/com/intelligt/modbus/examples/SimpleSlaveTCP.java
+++ b/examples/com/intelligt/modbus/examples/SimpleSlaveTCP.java
@@ -58,6 +58,7 @@ public class SimpleSlaveTCP {
             tcpParameters.setPort(Modbus.TCP_PORT);
 
             slave = ModbusSlaveFactory.createModbusSlaveTCP(tcpParameters);
+            slave.setReadTimeout(0); // if not set default timeout is 1000ms, I think this must be set to 0 (infinitive timeout)
             Modbus.setLogLevel(Modbus.LogLevel.LEVEL_DEBUG);
 
             MyOwnDataHolder dh = new MyOwnDataHolder();


### PR DESCRIPTION
If Modbus TCP Client waits more than 1000ms between requests, this SimpleSlaveTCP closes connection and gives error:
WARNING: java.net.SocketTimeoutException: Read timed out